### PR TITLE
Add event-based API to `Client`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ version = "1.0.0-beta.5"
 optional = true
 
 [features]
-default = ["trace", "wallet", "rusqlite"]
+default = ["wallet", "rusqlite", "events", "callbacks", "trace"]
 trace = ["tracing", "tracing-subscriber"]
 wallet = ["bdk_wallet"]
 rusqlite = ["kyoto-cbf/database"]
+callbacks = []
+events = []
 
 [dev-dependencies]
 tokio = { version = "1.37", features = ["full"], default-features = false }
@@ -38,8 +40,12 @@ tracing-subscriber = { version = "0.3" }
 
 [[example]]
 name = "signet"
-required-features = ["rusqlite"]
+required-features = ["rusqlite", "callbacks"]
 
 [[example]]
 name = "wallet"
-required-features = ["wallet", "trace", "rusqlite"]
+required-features = ["wallet", "trace", "rusqlite", "callbacks"]
+
+[[example]]
+name = "events"
+required-features = ["wallet", "rusqlite", "events"]

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,48 @@
+use bdk_kyoto::builder::LightClientBuilder;
+use bdk_kyoto::{Event, LogLevel};
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::Wallet;
+
+/* Sync a bdk wallet using events*/
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/0/*)";
+    let change_desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/1/*)";
+
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(Network::Signet)
+        .lookahead(30)
+        .create_wallet_no_persist()?;
+
+    // The light client builder handles the logic of inserting the SPKs
+    let (node, mut client) = LightClientBuilder::new(&wallet)
+        .scan_after(170_000)
+        .build()
+        .unwrap();
+
+    tokio::task::spawn(async move { node.run().await });
+
+    loop {
+        if let Some(event) = client.next_event(LogLevel::Info).await {
+            match event {
+                Event::Log(log) => println!("INFO: {log}"),
+                Event::Warning(warning) => println!("WARNING: {warning}"),
+                Event::ScanResponse(full_scan_result) => {
+                    wallet.apply_update(full_scan_result).unwrap();
+                    println!(
+                        "INFO: Balance in BTC: {}",
+                        wallet.balance().total().to_btc()
+                    );
+                }
+                Event::PeersFound => println!("INFO: Connected to all necessary peers."),
+                Event::TxSent(txid) => println!("INFO: Broadcast transaction: {txid}"),
+                Event::TxFailed(failure_payload) => {
+                    println!("WARNING: Transaction failed to broadcast: {failure_payload:?}")
+                }
+                Event::StateChange(node_state) => println!("NEW TASK: {node_state}"),
+                Event::BlocksDisconnected(_) => {}
+            }
+        }
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -6,6 +6,7 @@
 //! printing the display to the console.
 //!
 //! ```rust
+//! #[cfg(feature = "callbacks")]
 //! use bdk_kyoto::logger::PrintLogger;
 //! use bdk_kyoto::Warning;
 //! use bdk_kyoto::NodeEventHandler;
@@ -15,7 +16,7 @@
 //! logger.warning(Warning::PeerTimedOut);
 //! ```
 //!
-//! For a more descriptive console log, the `tracing` feature may be used.
+//! For a more descriptive console log, the `trace` feature may be used.
 //!
 //! ```rust
 //! use bdk_kyoto::logger::TraceLogger;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -5,6 +5,7 @@ use tokio::task;
 use tokio::time;
 
 use bdk_kyoto::builder::LightClientBuilder;
+#[cfg(feature = "callbacks")]
 use bdk_kyoto::logger::PrintLogger;
 use bdk_kyoto::NodeDefault;
 use bdk_kyoto::TrustedPeer;
@@ -57,6 +58,7 @@ fn init_node(
 }
 
 #[tokio::test]
+#[cfg(feature = "callbacks")]
 async fn update_returns_blockchain_data() -> anyhow::Result<()> {
     let env = testenv()?;
 
@@ -118,6 +120,7 @@ async fn update_returns_blockchain_data() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "callbacks")]
 async fn update_handles_reorg() -> anyhow::Result<()> {
     let env = testenv()?;
 


### PR DESCRIPTION
Ahead of the bindings chat I thought a little more about an event-based API as opposed to the callback style we currently have. In this draft I only have a few `Event` types, but there would be a handful more. I still don't quite know if this would be a developer experience improvement. Just looking for an opinion on this rough draft.