### PR TITLE
Release `0.4.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_kyoto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Rob <rustaceanrob@protonmail.com>", "Bitcoin Dev Kit Developers"]
 description = "BDK blockchain integration using P2P light client Kyoto"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cutting a release so bindings may take advantage of some new improvements from `kyoto`, although nothing has happened here.