### PR TITLE
Redesign sending and receiving events

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,4 +1,4 @@
-use bdk_kyoto::builder::LightClientBuilder;
+use bdk_kyoto::builder::{LightClient, LightClientBuilder};
 use bdk_kyoto::{Event, LogLevel};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::Wallet;
@@ -16,7 +16,11 @@ async fn main() -> anyhow::Result<()> {
         .create_wallet_no_persist()?;
 
     // The light client builder handles the logic of inserting the SPKs
-    let (node, mut client) = LightClientBuilder::new(&wallet)
+    let LightClient {
+        sender: _,
+        mut receiver,
+        node,
+    } = LightClientBuilder::new(&wallet)
         .scan_after(170_000)
         .build()
         .unwrap();
@@ -24,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::task::spawn(async move { node.run().await });
 
     loop {
-        if let Some(event) = client.next_event(LogLevel::Info).await {
+        if let Some(event) = receiver.next_event(LogLevel::Info).await {
             match event {
                 Event::Log(log) => println!("INFO: {log}"),
                 Event::Warning(warning) => println!("WARNING: {warning}"),


### PR DESCRIPTION
As more changes crop up in the underlying client, I think it best to just expose these to the user if they are comfortable with the `clone`

I am also experiencing a UniFFI limitation where I can't broadcast transactions and update at the same time. This would enable that as well. I am thinking the "callbacks" feature might even be worth calling "uniffi" or "bindings" at this point...

Edit: I decided to rethink the architecture here. I think the main advantage of this library is to handle events form the light client in a way that is meaningful for the wallet. This means the `Client<K>` struct is almost always occupied by listening for events. To broadcast transactions or add scripts in practice, one would acquire a lock on the `Client<K>`, but this could be blocked for a while. Instead, we can split sending events and receiving events into different structures, which are free to receive events from the node and send events in parallel. 