### PR TITLE
Require `&Wallet` to `build` light client

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -20,9 +20,9 @@ async fn main() -> anyhow::Result<()> {
         sender: _,
         mut receiver,
         node,
-    } = LightClientBuilder::new(&wallet)
+    } = LightClientBuilder::new()
         .scan_after(170_000)
-        .build()
+        .build(&wallet)
         .unwrap();
 
     tokio::task::spawn(async move { node.run().await });

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -35,10 +35,10 @@ async fn main() -> anyhow::Result<()> {
         sender: _,
         mut receiver,
         node,
-    } = LightClientBuilder::new(&wallet)
+    } = LightClientBuilder::new()
         .scan_after(170_000)
         .peers(peers)
-        .build()
+        .build(&wallet)
         .unwrap();
 
     tokio::task::spawn(async move { node.run().await });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!         .network(Network::Signet)
 //!         .create_wallet_no_persist()?;
 //!
-//!     let LightClient { sender, mut receiver, node } = LightClientBuilder::new(&wallet).build()?;
+//!     let LightClient { sender, mut receiver, node } = LightClientBuilder::new().build(&wallet)?;
 //!
 //!     tokio::task::spawn(async move { node.run().await });
 //!
@@ -64,7 +64,7 @@
 //!         .network(Network::Signet)
 //!         .create_wallet_no_persist()?;
 //!
-//!     let LightClient { sender, mut receiver, node } = LightClientBuilder::new(&wallet).build()?;
+//!     let LightClient { sender, mut receiver, node } = LightClientBuilder::new().build(&wallet)?;
 //!
 //!     tokio::task::spawn(async move { node.run().await });
 //!

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -51,11 +51,11 @@ fn init_node(
     let port = peer.port();
     let mut peer = TrustedPeer::from_ip(ip);
     peer.port = Some(port);
-    Ok(LightClientBuilder::new(wallet)
+    Ok(LightClientBuilder::new()
         .peers(vec![peer])
         .data_dir(tempdir)
         .connections(1)
-        .build()?)
+        .build(wallet)?)
 }
 
 #[tokio::test]


### PR DESCRIPTION
Would allow for future builds that create a node for multiple wallets.