### PR TITLE
docs: automatically include README text in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,4 @@
-//! BDK-Kyoto is an extension of [Kyoto](https://github.com/rustaceanrob/kyoto), a client-side implementation of BIP157/BIP158.
-//! These proposals define a way for users to fetch transactions privately, using _compact block
-//! filters_. You may want to read the specification [here](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki).
-//!
-//! Kyoto runs as a psuedo-node, sending messages over the Bitcoin peer-to-peer layer, finding new
-//! peers to connect to, and managing a light-weight database of Bitcoin block headers. As such,
-//! developing a wallet application using this crate is distinct from a typical client/server
-//! relationship. Esplora and Electrum offer _proactive_ APIs, in that the servers will respond to
-//! events as they are requested. In the case of running a node as a background process, the
-//! developer experience is far more _reactive_, in that the node may emit any number of events, and
-//! the application may respond to them.
-//!
-//! BDK-Kyoto curates these events into structures that are easily handled by BDK APIs, making
-//! integration of compact block filters easily understood. Developers are free to use [`bdk_wallet`], or only primatives found in [`bdk_core`](https://docs.rs/bdk_core/latest/bdk_core/) and [`bdk_chain`].
-//!
+#![doc = include_str!("../README.md")]
 //! ## Examples
 //!
 //! If you have an existing project that leverages `bdk_wallet`, building the compact block filter


### PR DESCRIPTION
I thought this could be useful for keeping the rust docs in sync with `README.md`.