### PR TITLE
Make scanning requirements explicit

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,7 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 
 use bdk_kyoto::builder::{LightClientBuilder, ServiceFlags, TrustedPeer};
-use bdk_kyoto::{LightClient, RequesterExt};
+use bdk_kyoto::{LightClient, RequesterExt, ScanType};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::{KeychainKind, Wallet};
 use tokio::select;
@@ -33,6 +33,11 @@ async fn main() -> anyhow::Result<()> {
         .lookahead(30)
         .create_wallet_no_persist()?;
 
+    // With no persistence, each scan type is a recovery.
+    let scan_type = ScanType::Recovery {
+        from_height: 170_000,
+    };
+
     // The light client builder handles the logic of inserting the SPKs
     let LightClient {
         requester,
@@ -41,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
         mut update_subscriber,
         node,
     } = LightClientBuilder::new()
-        .scan_after(170_000)
+        .scan_type(scan_type)
         .peers(peers)
         .build(&wallet)
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,21 @@ impl WarningSubscriber {
     }
 }
 
+/// How to scan compact block filters on start up.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ScanType {
+    /// Start a wallet sync that is known to have no transactions.
+    New,
+    /// Sync the wallet from the last known wallet checkpoint to the rest of the network.
+    #[default]
+    Sync,
+    /// Recover an old wallet by scanning after the specified height.
+    Recovery {
+        /// The height in the block chain to begin searching for transactions.
+        from_height: u32,
+    },
+}
+
 /// Extend the functionality of [`Wallet`](bdk_wallet) for interoperablility
 /// with the light client.
 pub trait WalletExt {


### PR DESCRIPTION
There is a bit of guess-work going on when the user provides a wallet birthday. If the local chain tip is at height 0, then it is assumed that the user is trying to either 1. recover from the provided birthday 2. sync the chain from the latest checkpoint because its a new wallet. This is a little dangerous because a poor implementation may not configure the birthday, and would miss the old transactions. Also the code is convoluted and hard to reason about. To get around both of these, a `ScanType` is introduced to force the developer to specify what it is they are doing. If the implementation neglects this type and a user is trying to recover a wallet, the scan will start from height 0. To explicitly ignore old block headers and start a new wallet, one would pass `ScanType::New`

edit: I preserved the `scan_after` method on the builder, so this can technically be released as a patch release to the best of my semver knowledge