### PR TITLE
Remove `LogSubscriber` and `WarningSubscriber`

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -79,11 +79,15 @@ async fn main() -> anyhow::Result<()> {
                     requester.add_revealed_scripts(&wallet).await?;
                 }
             },
-            log = log_subscriber.next_log() => {
-                tracing::info!("{log}")
+            log = log_subscriber.recv() => {
+                if let Some(log) = log {
+                    tracing::info!("{log}")
+                }
             }
-            warn = warning_subscriber.next_warning() => {
-                tracing::warn!("{warn}")
+            warn = warning_subscriber.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}")
+                }
             }
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -55,7 +55,7 @@ pub use kyoto::{
     TrustedPeer,
 };
 
-use crate::{LightClient, LogSubscriber, ScanType, UpdateSubscriber, WalletExt, WarningSubscriber};
+use crate::{LightClient, ScanType, UpdateSubscriber, WalletExt};
 
 const RECOMMENDED_PEERS: u8 = 2;
 
@@ -171,8 +171,8 @@ impl LightClientBuilder {
         };
         Ok(LightClient {
             requester,
-            log_subscriber: LogSubscriber::new(log_rx),
-            warning_subscriber: WarningSubscriber::new(warn_rx),
+            log_subscriber: log_rx,
+            warning_subscriber: warn_rx,
             update_subscriber,
             node,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,10 @@ pub use kyoto::{
     TxBroadcast, TxBroadcastPolicy, Txid, Warning,
 };
 
-use kyoto::Receiver;
-use kyoto::UnboundedReceiver;
+#[doc(inline)]
+pub use kyoto::Receiver;
+#[doc(inline)]
+pub use kyoto::UnboundedReceiver;
 use kyoto::{BlockHash, Event, IndexedBlock};
 
 pub mod builder;
@@ -71,9 +73,9 @@ pub struct LightClient {
     /// Send events to a running node (i.e. broadcast a transaction).
     pub requester: Requester,
     /// Receive logs from the node as it runs.
-    pub log_subscriber: LogSubscriber,
+    pub log_subscriber: Receiver<Log>,
     /// Receive warnings from the node as it runs.
-    pub warning_subscriber: WarningSubscriber,
+    pub warning_subscriber: UnboundedReceiver<Warning>,
     /// Receive wallet updates from a node.
     pub update_subscriber: UpdateSubscriber,
     /// The underlying node that must be run to fetch blocks from peers.
@@ -149,48 +151,6 @@ impl UpdateSubscriber {
             tx_update,
             last_active_indices,
             chain: Some(self.chain.tip()),
-        }
-    }
-}
-
-/// Receive logs from the node as it runs to drive user interface changes.
-#[derive(Debug)]
-pub struct LogSubscriber {
-    receiver: Receiver<Log>,
-}
-
-impl LogSubscriber {
-    pub(crate) fn new(receiver: Receiver<Log>) -> Self {
-        Self { receiver }
-    }
-
-    /// Wait until the node emits a log for an indeterminant amount of time.
-    pub async fn next_log(&mut self) -> Log {
-        loop {
-            if let Some(log) = self.receiver.recv().await {
-                return log;
-            }
-        }
-    }
-}
-
-/// Receive wanrings from the node to act on or to drive user interface changes
-#[derive(Debug)]
-pub struct WarningSubscriber {
-    receiver: UnboundedReceiver<Warning>,
-}
-
-impl WarningSubscriber {
-    pub(crate) fn new(receiver: UnboundedReceiver<Warning>) -> Self {
-        Self { receiver }
-    }
-
-    /// Wait until the node emits a warning for an indeterminant amount of time.
-    pub async fn next_warning(&mut self) -> Warning {
-        loop {
-            if let Some(warning) = self.receiver.recv().await {
-                return warning;
-            }
         }
     }
 }


### PR DESCRIPTION
I noticed after the example was fully synced to the network, my computer started working overtime. I believe the loops involved in these futures are not implemented properly, as in they should actually register with the waker to be polled later. Instead they are just busy looping aimlessly and hogging cycles. Conceptually the `Receiver` type from `tokio` is not that difficult to understand, so I return them directly and inline the docs.