### PR TITLE
build: opt in to v3 dependency resolver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[resolver]
+incompatible-rust-versions = "fallback"


### PR DESCRIPTION
Resolve dependnecies using the fresh v3 resolve which is msrv-aware. Allows for easy checking that the library's code is msrv-compliant while not putting any restrictions on consumers.