### PR TITLE
Remove the optional `Update`

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -58,26 +58,24 @@ async fn main() -> anyhow::Result<()> {
     loop {
         select! {
             update = update_subscriber.update() => {
-                if let Some(update) = update {
-                    wallet.apply_update(update)?;
-                    tracing::info!("Tx count: {}", wallet.transactions().count());
-                    tracing::info!("Balance: {}", wallet.balance().total().to_sat());
-                    let last_revealed = wallet.derivation_index(KeychainKind::External);
-                    tracing::info!("Last revealed External: {:?}", last_revealed);
-                    tracing::info!(
-                        "Last revealed Internal: {:?}",
-                        wallet.derivation_index(KeychainKind::Internal)
-                    );
-                    tracing::info!("Local chain tip: {}", wallet.local_chain().tip().height());
-                    let next = wallet.reveal_next_address(KeychainKind::External).address;
-                    tracing::info!("Next receiving address: {next}");
-                    let fee_filter = requester.broadcast_min_feerate().await.unwrap();
-                    tracing::info!(
-                        "Broadcast minimum fee rate: {:#}",
-                        fee_filter
-                    );
-                    requester.add_revealed_scripts(&wallet)?;
-                }
+                wallet.apply_update(update)?;
+                tracing::info!("Tx count: {}", wallet.transactions().count());
+                tracing::info!("Balance: {}", wallet.balance().total().to_sat());
+                let last_revealed = wallet.derivation_index(KeychainKind::External);
+                tracing::info!("Last revealed External: {:?}", last_revealed);
+                tracing::info!(
+                    "Last revealed Internal: {:?}",
+                    wallet.derivation_index(KeychainKind::Internal)
+                );
+                tracing::info!("Local chain tip: {}", wallet.local_chain().tip().height());
+                let next = wallet.reveal_next_address(KeychainKind::External).address;
+                tracing::info!("Next receiving address: {next}");
+                let fee_filter = requester.broadcast_min_feerate().await.unwrap();
+                tracing::info!(
+                    "Broadcast minimum fee rate: {:#}",
+                    fee_filter
+                );
+                requester.add_revealed_scripts(&wallet)?;
             },
             log = log_subscriber.recv() => {
                 if let Some(log) = log {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,9 @@
 //!     tokio::task::spawn(async move { node.run().await });
 //!
 //!     loop {
-//!         if let Some(update) = update_subscriber.update().await {
-//!             wallet.apply_update(update)?;
-//!             return Ok(());
-//!         }
+//!         let update = update_subscriber.update().await;
+//!         wallet.apply_update(update)?;
+//!         return Ok(());
 //!     }
 //! }
 //! ```
@@ -104,7 +103,7 @@ impl UpdateSubscriber {
     /// Return the most recent update from the node once it has synced to the network's tip.
     /// This may take a significant portion of time during wallet recoveries or dormant wallets.
     /// Note that you may call this method in a loop as long as the node is running.
-    pub async fn update(&mut self) -> Option<Update> {
+    pub async fn update(&mut self) -> Update {
         while let Some(message) = self.receiver.recv().await {
             match message {
                 Event::Block(IndexedBlock { height, block }) => {
@@ -119,16 +118,9 @@ impl UpdateSubscriber {
                     }
                 }
                 Event::Synced(SyncUpdate {
-                    tip,
+                    tip: _,
                     recent_history,
                 }) => {
-                    if self.chain_changeset.is_empty()
-                        && self.chain.tip().height() == tip.height
-                        && self.chain.tip().hash() == tip.hash
-                    {
-                        // return early if we're already synced
-                        return None;
-                    }
                     recent_history.into_iter().for_each(|(height, header)| {
                         self.chain_changeset
                             .insert(height, Some(header.block_hash()));
@@ -137,7 +129,7 @@ impl UpdateSubscriber {
                 }
             }
         }
-        Some(self.get_scan_response())
+        self.get_scan_response()
     }
 
     // When the client is believed to have synced to the chain tip of most work,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -93,10 +93,7 @@ async fn update_returns_blockchain_data() -> anyhow::Result<()> {
     // run node
     task::spawn(async move { node.run().await });
     // get update
-    let res = update_subscriber
-        .update()
-        .await
-        .expect("should have update");
+    let res = update_subscriber.update().await;
     let Update {
         tx_update,
         chain,
@@ -159,10 +156,7 @@ async fn update_handles_reorg() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // get update
-    let res = update_subscriber
-        .update()
-        .await
-        .expect("should have update");
+    let res = update_subscriber.update().await;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor.block_id.hash, blockhash);
     assert_eq!(anchor_txid, txid);
@@ -175,10 +169,7 @@ async fn update_handles_reorg() -> anyhow::Result<()> {
     wait_for_height(&env, 103).await?;
 
     // expect tx to confirm at same height but different blockhash
-    let res = update_subscriber
-        .update()
-        .await
-        .expect("should have update");
+    let res = update_subscriber.update().await;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor_txid, txid);
     assert_eq!(anchor.block_id.height, 102);
@@ -226,10 +217,7 @@ async fn update_handles_dormant_wallet() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // get update
-    let res = update_subscriber
-        .update()
-        .await
-        .expect("should have update");
+    let res = update_subscriber.update().await;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor.block_id.hash, blockhash);
     assert_eq!(anchor_txid, txid);
@@ -253,10 +241,7 @@ async fn update_handles_dormant_wallet() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // expect tx to confirm at same height but different blockhash
-    let res = update_subscriber
-        .update()
-        .await
-        .expect("should have update");
+    let res = update_subscriber.update().await;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor_txid, txid);
     assert_eq!(anchor.block_id.height, 102);


### PR DESCRIPTION
The optional case for `UpdateSubscriber::update` returning a `None` value can only occur if the user:
1. Syncs the wallet to the latest chain tip
2. Closes the application
3. Reopens the application and re-syncs to the same tip

While this may happen there doesn't seem to be any harm in applying the same update twice to a wallet. For developer ease-of-use, the optional case can be ignored and a repeated update can be issued in this edge case.