### PR TITLE
Return error if channel reports `None`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ bdk_wallet = { version = "1" }
 kyoto-cbf = { version = "0.11.0", default-features = false, features = ["rusqlite"] }
 
 [dev-dependencies]
-tokio = { version = "1.37", features = ["full"], default-features = false }
+tokio = { version = "1", features = ["full"], default-features = false }
 anyhow = "1.0"
-bdk_testenv = "0.9.0"
+bdk_testenv = { version = "0.12.0", default-features = true }
 tempfile = "3.12.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         select! {
             update = update_subscriber.update() => {
-                wallet.apply_update(update)?;
+                wallet.apply_update(update?)?;
                 tracing::info!("Tx count: {}", wallet.transactions().count());
                 tracing::info!("Balance: {}", wallet.balance().total().to_sat());
                 let last_revealed = wallet.derivation_index(KeychainKind::External);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -93,7 +93,7 @@ async fn update_returns_blockchain_data() -> anyhow::Result<()> {
     // run node
     task::spawn(async move { node.run().await });
     // get update
-    let res = update_subscriber.update().await;
+    let res = update_subscriber.update().await?;
     let Update {
         tx_update,
         chain,
@@ -156,7 +156,7 @@ async fn update_handles_reorg() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // get update
-    let res = update_subscriber.update().await;
+    let res = update_subscriber.update().await?;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor.block_id.hash, blockhash);
     assert_eq!(anchor_txid, txid);
@@ -169,7 +169,7 @@ async fn update_handles_reorg() -> anyhow::Result<()> {
     wait_for_height(&env, 103).await?;
 
     // expect tx to confirm at same height but different blockhash
-    let res = update_subscriber.update().await;
+    let res = update_subscriber.update().await?;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor_txid, txid);
     assert_eq!(anchor.block_id.height, 102);
@@ -217,7 +217,7 @@ async fn update_handles_dormant_wallet() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // get update
-    let res = update_subscriber.update().await;
+    let res = update_subscriber.update().await?;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor.block_id.hash, blockhash);
     assert_eq!(anchor_txid, txid);
@@ -241,7 +241,7 @@ async fn update_handles_dormant_wallet() -> anyhow::Result<()> {
     task::spawn(async move { node.run().await });
 
     // expect tx to confirm at same height but different blockhash
-    let res = update_subscriber.update().await;
+    let res = update_subscriber.update().await?;
     let (anchor, anchor_txid) = *res.tx_update.anchors.iter().next().unwrap();
     assert_eq!(anchor_txid, txid);
     assert_eq!(anchor.block_id.height, 102);


### PR DESCRIPTION
> This method returns None if the channel has been closed and there are
no remaining messages in the channel’s buffer. This indicates that no further values can ever be received from this Receiver.

When a channel returns `None`, we know that all sending halves of the channel have been dropped and no more messages may be received. In this case that means that the node has stopped running, as there is only a single sending halve that emits node events.