### PR TITLE
Use `CheckPoint` for chain updates

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -51,7 +51,7 @@
 //! }
 //! ```
 
-use std::{collections::BTreeMap, fmt::Display};
+use std::fmt::Display;
 
 use bdk_wallet::{chain::IndexedTxGraph, Wallet};
 use kyoto::HeaderCheckpoint;
@@ -86,7 +86,7 @@ impl NodeBuilderExt for NodeBuilder {
             // provided
             ScanType::New => (),
             ScanType::Sync => {
-                let block_id = wallet.local_chain().tip();
+                let block_id = wallet.latest_checkpoint();
                 let header_cp = HeaderCheckpoint::new(block_id.height(), block_id.hash());
                 self = self.after_checkpoint(header_cp);
             }
@@ -110,9 +110,8 @@ impl NodeBuilderExt for NodeBuilder {
         let indexed_graph = IndexedTxGraph::new(wallet.spk_index().clone());
         let update_subscriber = UpdateSubscriber {
             receiver: event_rx,
-            chain: wallet.local_chain().clone(),
+            cp: wallet.latest_checkpoint(),
             graph: indexed_graph,
-            chain_changeset: BTreeMap::new(),
         };
         Ok(LightClient {
             requester,


### PR DESCRIPTION
From the docs:
> Checkpoints are cheaply cloneable

We can abuse that fact a bit and internally update a `CheckPoint` whenever we receive chain events. With Kyoto able to emit what was accepted to the new chain of most work, we should now be able to use `CheckPoint::insert`, which seems to have the desired behavior.

1. If the checkpoint is already there, it is ignored
2. If there is a conflicting checkpoint, the older ones at or above the height will be removed, exactly what we want for a reorg
3. Anything inserted at a greater height is appended