### PR TITLE
chore: update bdk_wallet compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ documentation = "https://docs.rs/bdk-kyoto"
 readme = "README.md"
 keywords = ["bitcoin", "peer-to-peer", "light-client"]
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [dependencies]
-bdk_wallet = { version = "2" }
+bdk_wallet = "3"
 bip157 = { version = "0.4.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
#154 "Relax bdk_wallet dependency for 3.0.0-rc.1 compatibility"

#### Notes
I have the dependency as 3.0.0-rc.1 rather than "3" because I think until stable 3.0.0 exists the prerelease must be specified explicitly

I left rust-version unchanged in this PR to keep the change narrowly scoped to the bdk_wallet compatibility bump, but might want to bump to 1.85.0 to match bdk_wallet 3.0.0-rc.1’s ?