### PR TITLE
Add `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "bdk-kyoto development environment";
+
+  inputs = {
+    # Pinned to nixos-25.05: newer revisions of nixpkgs ship a
+    # blockstream-electrs whose CLI moved from `--cookie-file` to `--cookie`,
+    # This is a break in the `electrs` crate.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          # `blockstream-electrs` in this nixpkgs revision transitively pulls
+          # in `python3.12-ecdsa-0.19.1`, which nixpkgs marks insecure.
+          config.permittedInsecurePackages = [ "python3.12-ecdsa-0.19.1" ];
+        };
+
+        # Upstream tests are failing. Skips the tests on install.
+        blockstream-electrs = pkgs.blockstream-electrs.overrideAttrs (_: {
+          doCheck = false;
+        });
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.bitcoind
+            blockstream-electrs
+          ];
+
+          shellHook = ''
+            export BITCOIND_EXE="${pkgs.bitcoind}/bin/bitcoind"
+            export ELECTRS_EXE="${blockstream-electrs}/bin/electrs"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
We should not require the blockstream electrs is installed system wide for NixOS users. This adds a flake used in BDK testenv